### PR TITLE
Allow transfer of interest rate contract owner role

### DIFF
--- a/contracts/InterestRateModels/JumpRateModelV2.sol
+++ b/contracts/InterestRateModels/JumpRateModelV2.sol
@@ -133,6 +133,15 @@ contract BaseJumpRateModelV2 {
 
         emit NewInterestParams(baseRatePerBlock, multiplierPerBlock, jumpMultiplierPerBlock, kink);
     }
+
+    /**
+     * @notice external function to transfer owner role
+     * @param _newOwner The new owner address
+     */
+    function setAdmin(address _newOwner) external {
+        require(msg.sender == owner, "only the owner may call this function.");
+        owner = _newOwner;
+    }
 }
 
 /**


### PR DESCRIPTION
This changes allows us to set the multisig as the admin and still deploy the contract on different chains with the same address.